### PR TITLE
chore: 로그인 리다이렉트 시 개발, 배포 주소 수정

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL=https://leafup-prod-api.duckdns.org
+VITE_API_BASE_URL=https://leafup-prod-api.duckdns.org/api

--- a/src/pages/loginMain.jsx
+++ b/src/pages/loginMain.jsx
@@ -6,10 +6,11 @@ import GoogleLogo from "../assets/GoogleLogo.png";
 
 export default function LoginMain() {
 
+  const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
   // 로그인 공통 함수
   const handleLogin = (provider) => {
     // axios 대신 브라우저가 직접 이동 → 백엔드가 302로 리다이렉트 처리
-    window.location.href = `/api/v1/oauth2/login?provider=${provider}`;
+    window.location.href = `${apiBaseUrl}/v1/oauth2/login?provider=${provider}`;
   };
 
 


### PR DESCRIPTION
## 📌 작업 개요
- LoginMain 컴포넌트에서 개발/배포 환경에 맞는 API Base URL 적용

## ✨ 작업 상세 내용
- window.location.href를 환경변수 VITE_API_BASE_URL로 변경
- .env.development: VITE_API_BASE_URL= /api (프록시 사용)
- .env.production: VITE_API_BASE_URL= (배포용)
	•	기존 하드코딩된 /api/v1/oauth2/login 경로를 ${apiBaseUrl}/v1/oauth2/login으로 변경
- 환경에 따라 로그인 요청이 올바른 URL로 전달되도록 수정
